### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/themoviedb-api.gemspec
+++ b/themoviedb-api.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/18Months/themoviedb-api'
   s.summary     = %q{A simple to use Ruby wrapper for the The Movie Database API.}
   s.description = %q{Provides a simple and intuitive interface for the Movie Database API making use of OpenStruct.}
-  s.rubyforge_project = 'themoviedb-api'
   s.license     = 'MIT'
 
   s.files         = `git ls-files`.split($/)


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436