### PR TITLE
README: Drop gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 :facepunch: Battle-tested at [18Months](http://www.18months.it)
 
 [![Build Status](https://travis-ci.org/18Months/themoviedb-api.svg?branch=master)](https://travis-ci.org/18Months/themoviedb-api)
-[![Dependency Status](https://gemnasium.com/18Months/themoviedb-api.svg)](https://gemnasium.com/18Months/themoviedb-api)
 [![Gem Version](https://badge.fury.io/rb/themoviedb-api.svg)](http://badge.fury.io/rb/themoviedb-api)
 [![Coverage Status](https://coveralls.io/repos/18Months/themoviedb-api/badge.svg)](https://coveralls.io/r/18Months/themoviedb-api)
 [![security](https://hakiri.io/github/18Months/themoviedb-api/master.svg)](https://hakiri.io/github/18Months/themoviedb-api/master)


### PR DESCRIPTION
The service has closed. This PR removes the badge, which makes it look like a TODO.