### PR TITLE
Fix bug with find endpoint returning TV episodes for TV season searches and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.2 (2020-10-30)
+
+Minor:
+
+  - Fix the TV season and TV episode find endpoint returning results for each other
+
 ## 1.3.0 (2018-03-19)
 
 Minor:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    themoviedb-api (1.3.0)
+    themoviedb-api (1.3.2)
       rest-client (~> 2.0, >= 2.0)
 
 GEM
@@ -20,19 +20,21 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.1.5)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.7)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.3.1)
-    mime-types (3.1)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2020.0512)
     netrc (0.11.0)
     public_suffix (3.0.2)
     rake (13.0.1)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -61,7 +63,7 @@ GEM
     tins (1.16.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.7)
     vcr (4.0.0)
     webmock (3.3.0)
       addressable (>= 2.3.6)
@@ -82,4 +84,4 @@ DEPENDENCIES
   webmock (~> 3.3, >= 3.3)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/lib/tmdb/find.rb
+++ b/lib/tmdb/find.rb
@@ -30,7 +30,7 @@ module Tmdb
     def self.tv_season(id, filters={})
       result = Resource.new("/find/#{id}", filters).get
 
-      result['tv_episode_results'].map do |entry|
+      result['tv_season_results'].map do |entry|
         TV.new(entry)
       end
     end
@@ -38,7 +38,7 @@ module Tmdb
     def self.tv_episode(id, filters={})
       result = Resource.new("/find/#{id}", filters).get
 
-      result['tv_season_results'].map do |entry|
+      result['tv_episode_results'].map do |entry|
         TV.new(entry)
       end
     end

--- a/lib/tmdb/version.rb
+++ b/lib/tmdb/version.rb
@@ -1,3 +1,3 @@
 module Tmdb
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/find_spec.rb
+++ b/spec/find_spec.rb
@@ -75,7 +75,7 @@ describe Tmdb::Find do
   context '#tv_season' do
     let(:tv_season) do
       VCR.use_cassette 'find/tv_season' do
-        Tmdb::Find.tv_season('121361', external_source: 'tvdb_id')
+        Tmdb::Find.tv_season(62735, external_source: 'tvdb_id')
       end
     end
 
@@ -90,7 +90,7 @@ describe Tmdb::Find do
   context '#tv_episode' do
     let(:tv_episode) do
       VCR.use_cassette 'find/tv_episode' do
-        Tmdb::Find.tv_episode('121361', external_source: 'tvdb_id')
+        Tmdb::Find.tv_episode('tt3222784', external_source: 'imdb_id')
       end
     end
 


### PR DESCRIPTION
This is my first open source PR so apologies if I've done this incorrectly.

The find endpoint plucks the TV season search results for the TV episode find method and vice versa. I fixed this typo and updated the related tests.

For example, using the imdb_id for Silicon Valley S01E01 tt3222784, we should expect to see no results for a tv_season search and one result for a tv_episode search:

On 1.3.1 (incorrectly returns a TV episode result from a tv_season search):
```
[1] pry(main)> ap Tmdb::Find.tv_episode('tt3222784', external_source: 'imdb_id')
[]
=> nil
[2] pry(main)> ap Tmdb::Find.tv_season('tt3222784', external_source: 'imdb_id')
[
    [0] Tmdb::TV {
               :air_date => "2014-04-06",
         :episode_number => 1,
                     :id => 972002,
                   :name => "Minimum Viable Product",
               :overview => "Attending an elaborate launch party, Richard and his computer programmer friends - Big Head, Dinesh and Gilfoyle - dream of making it big. Instead, they're living in the communal Hacker Hostel owned by former programmer Erlich, who gets to claim ten percent of anything they invent there. When it becomes clear that Richard has developed a powerful compression algorithm for his website, Pied Piper, he finds himself courted by Gavin Belson, his egomaniacal corporate boss, who offers a $10 million buyout by his firm, Hooli. But Richard holds back when well-known investor Peter Gregory makes a counteroffer.",
        :production_code => "",
          :season_number => 1,
                :show_id => 60573,
             :still_path => "/zXr9tjwoL7L3YYKiXjMutwRS20U.jpg",
           :vote_average => 7.25,
             :vote_count => 16
    }
]
=> nil
```

With this PR (expected behaviour):
```
[1] pry(main)> ap Tmdb::Find.tv_episode('tt3222784', external_source: 'imdb_id')
[
    [0] Tmdb::TV {
               :air_date => "2014-04-06",
         :episode_number => 1,
                     :id => 972002,
                   :name => "Minimum Viable Product",
               :overview => "Attending an elaborate launch party, Richard and his computer programmer friends - Big Head, Dinesh and Gilfoyle - dream of making it big. Instead, they're living in the communal Hacker Hostel owned by former programmer Erlich, who gets to claim ten percent of anything they invent there. When it becomes clear that Richard has developed a powerful compression algorithm for his website, Pied Piper, he finds himself courted by Gavin Belson, his egomaniacal corporate boss, who offers a $10 million buyout by his firm, Hooli. But Richard holds back when well-known investor Peter Gregory makes a counteroffer.",
        :production_code => "",
          :season_number => 1,
                :show_id => 60573,
             :still_path => "/zXr9tjwoL7L3YYKiXjMutwRS20U.jpg",
           :vote_average => 7.25,
             :vote_count => 16
    }
]
=> nil
[2] pry(main)> ap Tmdb::Find.tv_season('tt3222784', external_source: 'imdb_id')
[]
=> nil
```