### PR TITLE
Add github actions for rspec

### DIFF
--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -1,0 +1,30 @@
+name: Ruby specs
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Tests for ${{ matrix.ruby.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - { name: "Ruby 3.2.x", value: 3.2.0 }
+          - { name: "Ruby 3.1.x", value: 3.1.3 }
+          - { name: "Ruby 3.0.x", value: 3.0.5 }
+          - { name: "Ruby 2.7.x", value: 2.7.7 }
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby.value }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec


### PR DESCRIPTION
Adding github actions for different versions of Ruby.

Nowadays, it will fail for some versions as the patch is not merged.

Also, I suppose it is needed to activate GH in the repository config. In the forked repository is properly run: https://github.com/cineol-gems/themoviedb-api/pull/2