### PR TITLE
Fix Tmdb::Struct for Ruby 2.7

### DIFF
--- a/lib/tmdb/struct.rb
+++ b/lib/tmdb/struct.rb
@@ -4,8 +4,16 @@ module Tmdb
       @table = {}
 
       if data
-        data.each do |k,v|
-          set_ostruct_member_value! k, analyze_value(v)
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+          data.each do |k,v|
+            set_ostruct_member_value! k, analyze_value(v)
+          end
+        else
+          data.each do |k,v|
+            @table[k.to_sym] = analyze_value(v)
+
+            new_ostruct_member!(k)
+          end
         end
       end
     end


### PR DESCRIPTION
With the fix for Ruby 3 looks like I broke the support for 2.7 (red specs on 2.7 regarding undefined method `new_ostruct_member`, it should be `new_ostruct_member!`)

This PR should fix this.