### PR TITLE
Fix set key for ruby 2.7

### DIFF
--- a/lib/tmdb/struct.rb
+++ b/lib/tmdb/struct.rb
@@ -5,7 +5,7 @@ module Tmdb
 
       if data
         data.each do |k,v|
-          set_ostruct_member_value! k, analyze_value(v)
+          self[k] = analyze_value(v)
         end
       end
     end


### PR DESCRIPTION
The previous fix `set_ostruct_member_value!` does not work for ruby lesser than 3. As far as I know, the `[]=` OpenStruct syntax is supported in all the ruby versions > 2.7